### PR TITLE
Fix microphone permission request silently failing

### DIFF
--- a/VoiceWrite/VoiceWrite.entitlements
+++ b/VoiceWrite/VoiceWrite.entitlements
@@ -5,5 +5,9 @@
     <!-- Hardened runtime exceptions -->
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <false/>
+
+    <!-- Required for microphone access under Hardened Runtime -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add `com.apple.security.device.audio-input` entitlement to `VoiceWrite.entitlements`
- Without this entitlement, `AVCaptureDevice.requestAccess(for: .audio)` silently fails under Hardened Runtime — the system permission dialog never appears
- The "Request" button in Settings → Permissions had no visible effect because of this

Fixes #1

## Root Cause
The app is signed with Hardened Runtime (`codesign -o runtime`), which blocks hardware access by default. Microphone access requires an explicit `com.apple.security.device.audio-input` entitlement. `NSMicrophoneUsageDescription` in Info.plist alone is not sufficient.

## Test plan
- [ ] Build with `make app`
- [ ] Launch app fresh (or reset microphone permission via `tccutil reset Microphone com.voicewrite.app`)
- [ ] Click "Request" in Settings → Permissions → Microphone
- [ ] Verify system permission dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)